### PR TITLE
fix: Ensure .taskmaster subdirectories are always created

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -176,8 +176,10 @@ fi
 
 # Initialize Taskmaster
 print_status "Initializing Taskmaster..."
+# Always ensure the full directory structure exists, as .taskmaster exists
+# in the repo but its subdirectories may not.
+mkdir -p .taskmaster/{docs,templates,tasks/{todo,in-progress,done}}
 if [ ! -d ".taskmaster" ]; then
-    mkdir -p .taskmaster/{docs,templates,tasks/{todo,in-progress,done}}
     print_success "Created Taskmaster directory structure"
 fi
 


### PR DESCRIPTION
The setup.sh script failed to create the necessary subdirectories inside the .taskmaster directory (e.g., .taskmaster/docs). This was because the script only ran the `mkdir` command if the parent `.taskmaster` directory did not exist.

Since the `.taskmaster` directory is present in the repository by default, the `mkdir` command was never executed. This caused a subsequent `cp` command, which relied on the `.taskmaster/docs` directory, to fail, halting the setup process.

This commit moves the `mkdir -p` command out of the conditional block, ensuring it always runs. The `-p` flag makes this operation idempotent, so it safely creates the required directory structure without erroring if the directories already exist.

## Summary by Sourcery

Bug Fixes:
- Move the mkdir -p command outside the existence check to reliably create .taskmaster/{docs,templates,tasks/...}